### PR TITLE
Update codeclimate/php-test-reporter requirement from ^0.3.2 to ^0.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "linfo/linfo": "~4.0"
   },
   "require-dev": {
-    "codeclimate/php-test-reporter": "^0.3.2",
+    "codeclimate/php-test-reporter": "^0.4.4",
     "laracasts/testdummy": "~2.0",
     "laravel/framework": "~5.0",
     "orchestra/testbench": "~3.0",


### PR DESCRIPTION
Updates the requirements on codeclimate/php-test-reporter to permit the latest version.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>